### PR TITLE
Fix for relative redirects

### DIFF
--- a/lib/link_checker.rb
+++ b/lib/link_checker.rb
@@ -64,7 +64,15 @@ class LinkChecker
             return Good.new(:uri_string => uri.to_s)
           end
         when Net::HTTPRedirection then
-          return self.check_uri(URI(response['location']), true)
+          # If the redirect is relative we need to build a new uri
+          # using the current uri as a base.  This isn't perfect.
+          if response['location'].match(/^http/) 
+            new_uri = URI(response['location'])
+          else
+            new_uri = URI.join("#{uri.scheme}://#{uri.host}:#{uri.port}", response['location'])
+          end
+          
+          return self.check_uri(new_uri, true)
         else
           return Error.new(:uri_string => uri.to_s, :error => response)
         end

--- a/spec/link-checker_spec.rb
+++ b/spec/link-checker_spec.rb
@@ -42,6 +42,7 @@ describe LinkChecker do
 
       @relative_redirect_1 = URI('http://www.relative.com/somewhere')
       @relative_redirect_2 = URI('http://relative.com/somewhere')
+      @relative_redirect_location = '/somewhere/else/'
       @relative_redirect_3 = URI('http://relative.com/somewhere/else/')
     end
 
@@ -78,7 +79,7 @@ describe LinkChecker do
 	FakeWeb.register_uri(:get, @relative_redirect_1.to_s,
           :location => @relative_redirect_2.to_s, :status => ["302", "Moved"])	
 	FakeWeb.register_uri(:get, @relative_redirect_2.to_s,
-	  :location => '/somewhere/else/', :status => ["302", "Moved"])
+	  :location => @relative_redirect_location, :status => ["302", "Moved"])
 	FakeWeb.register_uri(:get, @relative_redirect_3.to_s,
           :body => "Yay, it worked!")
         result = LinkChecker.check_uri(@relative_redirect_1)

--- a/spec/link-checker_spec.rb
+++ b/spec/link-checker_spec.rb
@@ -39,6 +39,9 @@ describe LinkChecker do
         :body => "File not found", :status => ["404", "Missing"])
 
       @redirect_uri = URI('http://redirect.com')
+ 
+      @auc_uri = URI('http://www.auc.edu.au/devworld')
+      @auc_uri_good = URI('http://auc.edu.au/devworld/about/')
     end
 
     it "declares good links to be good." do
@@ -66,6 +69,15 @@ describe LinkChecker do
         result.class.should be LinkChecker::Error
       end
 
+    end
+
+    describe "follow redirects for http://www.auc.edu.au/devworld and" do
+
+      it "declares the final target to be good." do
+        result = LinkChecker.check_uri(@auc_uri)
+        result.class.should be LinkChecker::Redirect
+        result.final_destination_uri_string.should == @auc_uri_good.to_s
+      end
     end
 
   end

--- a/spec/link-checker_spec.rb
+++ b/spec/link-checker_spec.rb
@@ -39,9 +39,10 @@ describe LinkChecker do
         :body => "File not found", :status => ["404", "Missing"])
 
       @redirect_uri = URI('http://redirect.com')
- 
-      @auc_uri = URI('http://www.auc.edu.au/devworld')
-      @auc_uri_good = URI('http://auc.edu.au/devworld/about/')
+
+      @relative_redirect_1 = URI('http://www.relative.com/somewhere')
+      @relative_redirect_2 = URI('http://relative.com/somewhere')
+      @relative_redirect_3 = URI('http://relative.com/somewhere/else/')
     end
 
     it "declares good links to be good." do
@@ -71,12 +72,18 @@ describe LinkChecker do
 
     end
 
-    describe "follow redirects for http://www.auc.edu.au/devworld and" do
+    describe "follow relative redirects for and" do
 
       it "declares the final target to be good." do
-        result = LinkChecker.check_uri(@auc_uri)
+	FakeWeb.register_uri(:get, @relative_redirect_1.to_s,
+          :location => @relative_redirect_2.to_s, :status => ["302", "Moved"])	
+	FakeWeb.register_uri(:get, @relative_redirect_2.to_s,
+	  :location => '/somewhere/else/', :status => ["302", "Moved"])
+	FakeWeb.register_uri(:get, @relative_redirect_3.to_s,
+          :body => "Yay, it worked!")
+        result = LinkChecker.check_uri(@relative_redirect_1)
         result.class.should be LinkChecker::Redirect
-        result.final_destination_uri_string.should == @auc_uri_good.to_s
+        result.final_destination_uri_string.should == @relative_redirect_3.to_s
       end
     end
 


### PR DESCRIPTION
I have made a minor fix to support relative redirects, i.e. when the `response['location']` is just a path without the host.   I have added some tests which are using the real world example where I found the problem.  Ruby is not my language so I have no idea if I have fixed the problem in the most optimal way.

The example URL is [http://www.auc.edu.au/devworld](http://www.auc.edu.au/devworld) which redirects to [http://auc.edu.au/devworld/about/](http://auc.edu.au/devworld/about/).  The link checker without the fix generates a connection error.  As I say, Ruby isn't my language so I don't know how to mock up a test for relative redirects.

Feel free to do what you will with my changes.  Thanks for the link checker.
